### PR TITLE
DEV-84 Implement basic donation functionality

### DIFF
--- a/src/donation/donation.controller.ts
+++ b/src/donation/donation.controller.ts
@@ -29,20 +29,6 @@ import { CreateDonationDto } from './dto/create-donation.dto';
 export class DonationController {
   constructor(private readonly donationService: DonationService) {}
 
-  @Get()
-  @ApiOperation({
-    summary: 'Get Donations',
-    description: 'Returns a list of all donations.',
-  })
-  @ApiOkResponse({
-    type: DonationEntity,
-    isArray: true,
-    description: 'List of all added donations.',
-  })
-  getDonations(): Promise<DonationEntity[]> {
-    return this.donationService.findDonations();
-  }
-
   @Get(':id')
   @ApiOperation({
     summary: 'Get Donation',

--- a/src/donation/donation.controller.ts
+++ b/src/donation/donation.controller.ts
@@ -1,12 +1,96 @@
-import { Controller, Get } from '@nestjs/common';
+import {
+  Body,
+  ClassSerializerInterceptor,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  ParseIntPipe,
+  Post,
+  UseInterceptors,
+} from '@nestjs/common';
 import { DonationService } from './donation.service';
+import { DonationEntity } from './models/donation.entity';
+import {
+  ApiBadRequestResponse,
+  ApiCreatedResponse,
+  ApiNoContentResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import { CreateDonationDto } from './dto/create-donation.dto';
 
+@ApiTags('Donations Management')
+@UseInterceptors(ClassSerializerInterceptor)
 @Controller('donations')
 export class DonationController {
   constructor(private readonly donationService: DonationService) {}
 
   @Get()
-  hello(): string {
-    return this.donationService.hello();
+  @ApiOperation({
+    summary: 'Get Donations',
+    description: 'Returns a list of all donations.',
+  })
+  @ApiOkResponse({
+    type: DonationEntity,
+    isArray: true,
+    description: 'List of all added donations.',
+  })
+  getDonations(): Promise<DonationEntity[]> {
+    return this.donationService.findDonations();
+  }
+
+  @Get(':id')
+  @ApiOperation({
+    summary: 'Get Donation',
+    description: 'Tries to find a single donation matching the given id.',
+  })
+  @ApiOkResponse({
+    type: DonationEntity,
+    description: 'Finds donation with matching id',
+  })
+  @ApiNotFoundResponse({
+    description: 'Donation with given id does not exist',
+  })
+  getDonation(@Param('id', ParseIntPipe) id: number): Promise<DonationEntity> {
+    return this.donationService.findDonationById(id);
+  }
+
+  @Post()
+  @ApiOperation({
+    summary: 'Add Donation',
+    description: 'Tries to add a new donation.',
+  })
+  @ApiCreatedResponse({
+    type: DonationEntity,
+    description: 'Created donation object',
+  })
+  @ApiNotFoundResponse({
+    description: 'Failed to find user adding the donation',
+  })
+  @ApiBadRequestResponse({
+    description: 'Donation creation failed. Please check request body',
+  })
+  async addDonation(@Body() body: CreateDonationDto): Promise<DonationEntity> {
+    return await this.donationService.createDonation(body);
+  }
+
+  @Delete(':id')
+  @HttpCode(204)
+  @ApiOperation({
+    summary: 'Delete Donation',
+    description: 'Tries to soft delete the donation if donation exists.',
+  })
+  @ApiNoContentResponse({
+    description: 'Donation successfully deleted',
+  })
+  @ApiNotFoundResponse({
+    description: 'Donation with given id does not exist',
+  })
+  async deleteDonation(@Param('id', ParseIntPipe) id: number): Promise<void> {
+    await this.donationService.removeDonation(id);
   }
 }

--- a/src/donation/donation.module.ts
+++ b/src/donation/donation.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { DonationEntity } from './models/donation.entity';
 import { DonationService } from './donation.service';
 import { DonationController } from './donation.controller';
+import { UserModule } from '../user/user.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([DonationEntity])],
+  imports: [UserModule, TypeOrmModule.forFeature([DonationEntity])],
   providers: [DonationService],
   controllers: [DonationController],
 })

--- a/src/donation/donation.service.ts
+++ b/src/donation/donation.service.ts
@@ -14,10 +14,6 @@ export class DonationService {
     private readonly userService: UserService,
   ) {}
 
-  async findDonations(): Promise<DonationEntity[]> {
-    return await this.donationRepository.find();
-  }
-
   async findDonationById(id: number): Promise<DonationEntity> {
     const donation = await this.donationRepository.findOneBy({
       id,

--- a/src/donation/donation.service.ts
+++ b/src/donation/donation.service.ts
@@ -1,16 +1,64 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DonationEntity } from './models/donation.entity';
 import { Repository } from 'typeorm';
+import { CreateDonationDto } from './dto/create-donation.dto';
+import { UserService } from '../user/user.service';
 
 @Injectable()
 export class DonationService {
   constructor(
     @InjectRepository(DonationEntity)
     private readonly donationRepository: Repository<DonationEntity>,
+    @Inject(UserService)
+    private readonly userService: UserService,
   ) {}
 
-  hello(): string {
-    return 'Hello from Donation Module';
+  async findDonations(): Promise<DonationEntity[]> {
+    return await this.donationRepository.find();
+  }
+
+  async findDonationById(id: number): Promise<DonationEntity> {
+    const donation = await this.donationRepository.findOneBy({
+      id,
+    });
+
+    if (!donation)
+      throw new HttpException('Donation not found', HttpStatus.NOT_FOUND);
+
+    return donation;
+  }
+
+  async createDonation(
+    createDonationDto: CreateDonationDto,
+  ): Promise<DonationEntity> {
+    const { user_id, ...donationDetails } = createDonationDto;
+    const user = await this.userService.findUserById(user_id);
+
+    try {
+      const newDonation = await this.donationRepository.create({
+        ...donationDetails,
+        user,
+      });
+      await this.donationRepository.save(newDonation);
+
+      return newDonation;
+    } catch (error) {
+      throw new HttpException(error.detail, HttpStatus.BAD_REQUEST);
+    }
+  }
+
+  /* With soft delete it is possible to later on
+   * implement restore functionality in case user
+   * has deleted donation by accident.
+   */
+  async removeDonation(id: number): Promise<void> {
+    const result = await this.donationRepository.softDelete(id);
+
+    if (!result.affected)
+      throw new HttpException(
+        `Donation with id ${id} not found`,
+        HttpStatus.NOT_FOUND,
+      );
   }
 }

--- a/src/donation/dto/create-donation.dto.ts
+++ b/src/donation/dto/create-donation.dto.ts
@@ -1,0 +1,81 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsEnum,
+  IsISO8601,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  Matches,
+} from 'class-validator';
+import { DonationType } from '../models/donation-type.model';
+
+export class CreateDonationDto {
+  @ApiProperty({
+    description: 'ID of user adding the donation',
+    example: 1,
+  })
+  @IsNotEmpty()
+  @IsNumber()
+  user_id: number;
+
+  @ApiProperty({
+    description: 'ID of user accompanying the requester',
+    example: 2,
+    nullable: true,
+  })
+  @IsNumber()
+  @IsOptional()
+  companion_user_id?: number;
+
+  @ApiProperty({
+    description: 'Type of Blood Donation',
+    example: 'whole',
+  })
+  @IsNotEmpty()
+  @IsEnum(DonationType)
+  donated_type: string;
+
+  @ApiProperty({
+    description: 'Amount of blood donated in milliliters',
+    example: 450,
+  })
+  @IsNotEmpty()
+  @IsNumber()
+  amount: number;
+
+  @ApiProperty({
+    description: 'Systolic and diastolic pressure at the time of donation',
+    example: '170/90',
+    nullable: true,
+  })
+  @Matches(/^\d{1,3}\/\d{1,3}$/, {
+    message:
+      "blood_pressure must be a string containing two numbers separated by '/' character, each number has maximum length of 3,",
+  })
+  blood_pressure?: string;
+
+  @ApiProperty({
+    description: 'Hemoglobin levels in g/l',
+    example: 140,
+    nullable: true,
+  })
+  hemoglobin?: number;
+
+  @ApiProperty({
+    description: 'User comments regarding the donation',
+    example: 'Nurse warned me about low hemoglobin levels.',
+    nullable: true,
+  })
+  details?: string;
+
+  @ApiProperty({
+    description: 'Time of the donation',
+    example: '2002-02-02T22:22:22.22Z',
+  })
+  @IsNotEmpty()
+  @IsISO8601({
+    strict: false,
+    strictSeparator: true,
+  })
+  donated_at: string;
+}

--- a/src/donation/models/donation-type.model.ts
+++ b/src/donation/models/donation-type.model.ts
@@ -1,4 +1,6 @@
 export enum DonationType {
   WHOLE_BLOOD = 'whole',
   BLOOD_PLASMA = 'plasma',
+  POWER_RED = 'power',
+  PLATELET = 'platelet',
 }

--- a/src/donation/models/donation-type.model.ts
+++ b/src/donation/models/donation-type.model.ts
@@ -1,0 +1,4 @@
+export enum DonationType {
+  WHOLE_BLOOD = 'whole',
+  BLOOD_PLASMA = 'plasma',
+}

--- a/src/donation/models/donation.entity.ts
+++ b/src/donation/models/donation.entity.ts
@@ -5,40 +5,98 @@ import {
   Entity,
   JoinColumn,
   ManyToOne,
+  OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { UserEntity } from '../../user/models/user.entity';
+import { ApiProperty } from '@nestjs/swagger';
 
 @Entity('donation')
 export class DonationEntity {
+  @ApiProperty({
+    description: 'ID of the donation',
+    example: 1,
+  })
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ManyToOne(() => UserEntity, user => user.donations)
+  @ApiProperty({
+    description: 'ID of user adding the donation',
+    example: 1,
+  })
+  @Column({ nullable: true })
+  user_id: number;
+
+  @ManyToOne(() => UserEntity, user => user.donations, {
+    onDelete: 'SET NULL',
+  })
   @JoinColumn({ name: 'user_id' })
   user: UserEntity;
 
+  @ApiProperty({
+    description: 'ID of user accompanying the requester',
+    example: 2,
+    nullable: true,
+  })
   @Column({ nullable: true })
   companion_user_id: number;
 
+  @OneToOne(() => UserEntity, {
+    nullable: true,
+    onDelete: 'SET NULL',
+  })
+  @JoinColumn({ name: 'companion_user_id' })
+  companion_user: UserEntity;
+
+  @ApiProperty({
+    description: 'Type of Blood Donation',
+    example: 'whole',
+  })
   @Column()
   donated_type: string;
 
+  @ApiProperty({
+    description: 'Amount of blood donated in milliliters',
+    example: 450,
+  })
   @Column()
   amount: number;
 
+  @ApiProperty({
+    description: 'Systolic and diastolic pressure at the time of donation',
+    example: '170/90',
+    nullable: true,
+  })
   @Column({ nullable: true })
   blood_pressure: string;
 
+  @ApiProperty({
+    description: 'Hemoglobin levels in g/l',
+    example: 140,
+    nullable: true,
+  })
   @Column({ nullable: true })
   hemoglobin: number;
 
+  @ApiProperty({
+    description: 'User comments about the donation',
+    example: 'Nurse warned me about low hemoglobin levels.',
+    nullable: true,
+  })
   @Column({ nullable: true })
   details: string;
 
-  @Column({ type: 'timestamp' })
+  @ApiProperty({
+    description: 'Time of the donation',
+    example: '2002-02-02T22:22:22.22Z',
+  })
+  @Column({ type: 'timestamp with time zone' })
   donated_at: Date;
 
+  @ApiProperty({
+    description: 'Time of donation creation',
+    example: '2002-02-02T22:22:22.22Z',
+  })
   @CreateDateColumn()
   created_at: Date;
 

--- a/src/user/models/user.entity.ts
+++ b/src/user/models/user.entity.ts
@@ -84,7 +84,9 @@ export class UserEntity {
   @Column()
   experience: number;
 
-  @OneToMany(() => DonationEntity, donation => donation.user)
+  @OneToMany(() => DonationEntity, donation => donation.user, {
+    cascade: true,
+  })
   donations: DonationEntity[];
 
   @OneToMany(() => SocialMediaPostEntity, post => post.author)

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -22,6 +22,7 @@ import {
 } from '@nestjs/swagger';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UserEntity } from './models/user.entity';
+import { DonationEntity } from '../donation/models/donation.entity';
 
 @ApiTags('User Management')
 @UseInterceptors(ClassSerializerInterceptor)
@@ -35,10 +36,12 @@ export class UserController {
     description: 'Returns a list of all users.',
   })
   @ApiOkResponse({
+    type: UserEntity,
+    isArray: true,
     description: 'List of registered users',
   })
-  getUsers(): Promise<UserEntity[]> {
-    return this.userService.findUsers();
+  async getUsers(): Promise<UserEntity[]> {
+    return await this.userService.findUsers();
   }
 
   @Get(':id')
@@ -47,6 +50,7 @@ export class UserController {
     description: 'Tries to find a single user matching the given id.',
   })
   @ApiOkResponse({
+    type: UserEntity,
     description: 'Finds user with matching id',
   })
   @ApiNotFoundResponse({
@@ -56,20 +60,39 @@ export class UserController {
     return await this.userService.findUserById(id);
   }
 
+  @Get(':id/donations')
+  @ApiOperation({
+    summary: 'Get User Donations',
+    description: 'List all donations for given user.',
+  })
+  @ApiOkResponse({
+    type: DonationEntity,
+    isArray: true,
+    description: 'List of donations registered by given user',
+  })
+  @ApiNotFoundResponse({
+    description: 'User with given id does not exist',
+  })
+  async getUserDonations(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<DonationEntity[]> {
+    return await this.userService.findUserDonations(id);
+  }
+
   @Post()
   @ApiOperation({
     summary: 'Register User',
     description: 'Tries to save a new user.',
   })
   @ApiCreatedResponse({
-    description: 'Created user object with related user settings as response',
     type: UserEntity,
+    description: 'Created user object with related user settings as response',
   })
   @ApiBadRequestResponse({
     description: 'User creation failed. Please check request body',
   })
-  registerUser(@Body() body: CreateUserDto): Promise<UserEntity> {
-    return this.userService.createUser(body);
+  async registerUser(@Body() body: CreateUserDto): Promise<UserEntity> {
+    return await this.userService.createUser(body);
   }
 
   @Delete(':id')
@@ -79,12 +102,12 @@ export class UserController {
     description: 'Tries to delete an user if user with given id exists.',
   })
   @ApiNoContentResponse({
-    description: 'Deletes user with matching id',
+    description: 'User successfully deleted',
   })
   @ApiNotFoundResponse({
     description: 'User with given id does not exist',
   })
   async deleteUser(@Param('id', ParseIntPipe) id: number): Promise<void> {
-    await this.userService.remove(id);
+    await this.userService.removeUser(id);
   }
 }

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -4,10 +4,14 @@ import { UserController } from './user.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserEntity } from './models/user.entity';
 import { UserSettingEntity } from './models/user-setting.entity';
+import { DonationEntity } from '../donation/models/donation.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([UserEntity, UserSettingEntity])],
+  imports: [
+    TypeOrmModule.forFeature([UserEntity, UserSettingEntity, DonationEntity]),
+  ],
   providers: [UserService],
   controllers: [UserController],
+  exports: [UserService],
 })
 export class UserModule {}


### PR DESCRIPTION
**File changes:**
* `src/donation/donation.controller.ts` - Add four basic endpoints with OpenAPI docs:
  1. Get all donations.
  2. Get single donation by id.
  3. Create donation.
  4. Soft delete donation.
* `src/donation/donation.module.ts` - Import UserModule - needed because in DonationService I'm calling UserModule methods.
* `src/donation/donation.service.ts`
  1. Inject UserService.
  2. Implement logic for controller endpoints.
  3. When adding a donation first see if User with given user_id exists using UserService, if not - throw error.
  4. Since soft delete was required I've made an adnotation for the future that it's possible to restore records deleted this way.
* `src/donation/dto/create-donation.dto.ts`, `src/donation/models/donation-type.model.ts` - Validation of donation creation inputs.
* `src/donation/models/donation.entity.ts`, `src/user/models/user.entity.ts` - Add swagger, setup foreign key policies.
* `src/user/user.controller.ts` - minor fixes (async) & add endpoint for reading donations added by given user.
* `src/user/user.module.ts` - export UserService to be used in DonationModule & import DonationEntity to TypeORM.
* `src/user/user.service.ts`
  1. Inject Donation repository.
  2. Logic for new user endpoint.
  3. Logic for soft deleting donations when removing an user.

**Module exports/imports:**
In DonationModule I import UserService, so why not import DonationService instead of injecting Donation Repository?
1. UserService will continue to expand it's dependencies - services are harder to maintain&test than repos.
2. Avoiding circular dependency which will result in a crash or force me to use forwardRefs which are hell to handle as well.

So why even bothering importing UserService to DonationService? In this use-case it's simple enough and allows me to reuse existing code from UserService.