### PR TITLE
DEV-246 Add option to authorize in swagger

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,6 +1,11 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
-import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 
 @ApiTags('Base')
 @Controller('status')
@@ -8,6 +13,7 @@ export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get()
+  @ApiBearerAuth()
   @ApiOperation({
     summary: 'API Status Check',
     description:

--- a/src/blood-center/blood-center.controller.ts
+++ b/src/blood-center/blood-center.controller.ts
@@ -13,12 +13,14 @@ import { BloodCenterEntity } from './models/blood-center.entity';
 import { SaveBloodCenterDetailsDto } from './dto/save-blood-center-details.dto';
 import {
   ApiBadRequestResponse,
+  ApiBearerAuth,
   ApiCreatedResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
 } from '@nestjs/swagger';
+import { Public } from '../auth/guard/public-route.decorator';
 
 @ApiTags('Blood Centers')
 @UseInterceptors(ClassSerializerInterceptor)
@@ -27,6 +29,7 @@ export class BloodCenterController {
   constructor(private readonly bloodCenterService: BloodCenterService) {}
 
   @Get()
+  @ApiBearerAuth()
   @ApiOperation({
     summary: 'Get Blood Centers',
     description: 'Returns a list of all Blood Centers.',
@@ -41,6 +44,7 @@ export class BloodCenterController {
   }
 
   @Get(':city')
+  @ApiBearerAuth()
   @ApiOperation({
     summary: 'Get Blood Center',
     description:
@@ -60,6 +64,7 @@ export class BloodCenterController {
   }
 
   @Post('status')
+  @Public()
   @ApiOperation({
     summary: 'Update Blood Bank Capacity',
     description:

--- a/src/common/utilities/swagger.config.ts
+++ b/src/common/utilities/swagger.config.ts
@@ -8,7 +8,8 @@ export const swaggerConfig = (): Omit<OpenAPIObject, 'paths'> => {
   return new DocumentBuilder()
     .setTitle('Blood Donor API')
     .setDescription('Documentation for the Blood Donor Backend API')
-    .setVersion('0.4.0')
+    .setVersion('0.7.0')
+    .addBearerAuth({ in: 'header', type: 'http' })
     .build();
 };
 

--- a/src/donation/donation.controller.ts
+++ b/src/donation/donation.controller.ts
@@ -14,6 +14,7 @@ import { DonationService } from './donation.service';
 import { DonationEntity } from './models/donation.entity';
 import {
   ApiBadRequestResponse,
+  ApiBearerAuth,
   ApiCreatedResponse,
   ApiNoContentResponse,
   ApiNotFoundResponse,
@@ -30,6 +31,7 @@ export class DonationController {
   constructor(private readonly donationService: DonationService) {}
 
   @Get(':id')
+  @ApiBearerAuth()
   @ApiOperation({
     summary: 'Get Donation',
     description: 'Tries to find a single donation matching the given id.',
@@ -46,6 +48,7 @@ export class DonationController {
   }
 
   @Post()
+  @ApiBearerAuth()
   @ApiOperation({
     summary: 'Add Donation',
     description: 'Tries to add a new donation.',
@@ -65,6 +68,7 @@ export class DonationController {
   }
 
   @Delete(':id')
+  @ApiBearerAuth()
   @HttpCode(204)
   @ApiOperation({
     summary: 'Delete Donation',

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -7,7 +7,12 @@ import {
   HttpHealthIndicator,
   TypeOrmHealthIndicator,
 } from '@nestjs/terminus';
-import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 
 @ApiTags('Base')
 @Controller('health')
@@ -19,6 +24,7 @@ export class HealthController {
   ) {}
 
   @Get()
+  @ApiBearerAuth()
   @HealthCheck()
   @ApiOperation({
     summary: 'Health Check',

--- a/src/image/image.controller.ts
+++ b/src/image/image.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
 import { ImageService } from './image.service';
 import {
+  ApiBearerAuth,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
@@ -14,6 +15,7 @@ export class ImageController {
   constructor(private readonly imageService: ImageService) {}
 
   @Get(':id')
+  @ApiBearerAuth()
   @ApiOperation({
     summary: 'Get Image',
     description: 'Tries to find a single image matching the given id.',

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -10,6 +10,7 @@ import {
 } from '@nestjs/common';
 import { UserService } from './user.service';
 import {
+  ApiBearerAuth,
   ApiNoContentResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
@@ -26,6 +27,7 @@ export class UserController {
   constructor(private readonly userService: UserService) {}
 
   @Get()
+  @ApiBearerAuth()
   @ApiOperation({
     summary: 'Get Users',
     description: 'Returns a list of all users.',
@@ -40,6 +42,7 @@ export class UserController {
   }
 
   @Get(':id')
+  @ApiBearerAuth()
   @ApiOperation({
     summary: 'Get User',
     description: 'Tries to find a single user matching the given id.',
@@ -56,6 +59,7 @@ export class UserController {
   }
 
   @Get(':id/donations')
+  @ApiBearerAuth()
   @ApiOperation({
     summary: 'Get User Donations',
     description: 'List all donations for given user.',
@@ -75,6 +79,7 @@ export class UserController {
   }
 
   @Delete(':id')
+  @ApiBearerAuth()
   @HttpCode(204)
   @ApiOperation({
     summary: 'Delete User',


### PR DESCRIPTION
File changes mostly consists of adding a `@ApiBearerAuth()` decorator to controllers.
The only significant change is in `src/common/utilities/swagger.config.ts` where to the `DocumentBuilder` we pass the information about existing auth in bearer that allows us to then authorize the Swagger documentation.

![eg1](https://user-images.githubusercontent.com/39565249/234418357-bc4740fc-a0e1-415f-baae-8c17f68b64ef.png)
