### PR TITLE
Add support for disqualification

### DIFF
--- a/src/donation/donation.service.ts
+++ b/src/donation/donation.service.ts
@@ -32,6 +32,19 @@ export class DonationService {
 
   async createDonation(dto: CreateDonationDto): Promise<DonationEntity> {
     const { user_id, ...donationDetails } = dto;
+    if (!dto.disqualified) {
+      if (!dto.amount)
+        throw new HttpException(
+          'amount must be a number conforming to the specified constraints',
+          HttpStatus.BAD_REQUEST,
+        );
+      if (!dto.donated_type)
+        throw new HttpException(
+          'donated_type must be one of the following values: whole, plasma, power, platelet',
+          HttpStatus.BAD_REQUEST,
+        );
+    }
+
     const user = await this.userService.findUserById(user_id);
     const experienceReward = 50;
 
@@ -41,6 +54,8 @@ export class DonationService {
         user,
       });
       await this.donationRepository.save(newDonation);
+
+      if (dto.disqualified) return newDonation;
 
       this.eventEmitter.emit(
         'experience.increase',

--- a/src/donation/dto/create-donation.dto.ts
+++ b/src/donation/dto/create-donation.dto.ts
@@ -1,10 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
+  IsBoolean,
   IsEnum,
   IsISO8601,
   IsNotEmpty,
   IsNumber,
   IsOptional,
+  IsString,
   Matches,
 } from 'class-validator';
 import { DonationType } from '../../common/enum/donation-type.enum';
@@ -19,6 +21,13 @@ export class CreateDonationDto {
   user_id: number;
 
   @ApiProperty({
+    description: 'Whether the user was disqualified',
+    example: false,
+  })
+  @IsBoolean()
+  disqualified: boolean;
+
+  @ApiProperty({
     description: 'ID of user accompanying the requester',
     example: 2,
     nullable: true,
@@ -30,18 +39,20 @@ export class CreateDonationDto {
   @ApiProperty({
     description: 'Type of Blood Donation',
     example: 'whole',
+    nullable: true,
   })
-  @IsNotEmpty()
   @IsEnum(DonationType)
-  donated_type: string;
+  @IsOptional()
+  donated_type?: string;
 
   @ApiProperty({
     description: 'Amount of blood donated in milliliters',
     example: 450,
+    nullable: true,
   })
-  @IsNotEmpty()
   @IsNumber()
-  amount: number;
+  @IsOptional()
+  amount?: number;
 
   @ApiProperty({
     description: 'Systolic and diastolic pressure at the time of donation',
@@ -52,6 +63,7 @@ export class CreateDonationDto {
     message:
       "blood_pressure must be a string containing two numbers separated by '/' character, each number has maximum length of 3,",
   })
+  @IsOptional()
   blood_pressure?: string;
 
   @ApiProperty({
@@ -59,6 +71,8 @@ export class CreateDonationDto {
     example: 140,
     nullable: true,
   })
+  @IsString()
+  @IsOptional()
   hemoglobin?: number;
 
   @ApiProperty({
@@ -66,6 +80,8 @@ export class CreateDonationDto {
     example: 'Nurse warned me about low hemoglobin levels.',
     nullable: true,
   })
+  @IsString()
+  @IsOptional()
   details?: string;
 
   @ApiProperty({

--- a/src/feat/feat.service.ts
+++ b/src/feat/feat.service.ts
@@ -79,6 +79,7 @@ export class FeatService {
     const userDonations = await this.donationRepository.findAndCount({
       where: {
         user_id: payload.userId,
+        disqualified: false,
       },
     });
     const bloodDonatedInLiters: number =


### PR DESCRIPTION
* `src/donation/donation.service.ts` - Add error handling if donation is a success and amount or donated_type is missing (date of donation and user_id are required by default). Also, if disqualified don't bother sending events.
* `src/donation/dto/create-donation.dto.ts` - Primarily update dto to allow for null values.
* `src/feat/feat.service.ts` - When checking missions only consider donations that were a success.