### PR TITLE
Allow for null values in avatar property of user

### DIFF
--- a/src/user/dto/create-user.dto.ts
+++ b/src/user/dto/create-user.dto.ts
@@ -3,6 +3,7 @@ import {
   IsEnum,
   IsNotEmpty,
   IsNumber,
+  IsOptional,
   IsString,
 } from 'class-validator';
 import { BloodType } from '../../common/enum/blood-type.enum';
@@ -53,8 +54,9 @@ export class CreateUserDto {
   @ApiProperty({
     description: 'User avatar id',
     example: 1,
+    nullable: true,
   })
-  @IsNotEmpty()
+  @IsOptional()
   @IsNumber()
   avatar_id: number;
 }

--- a/src/user/models/user.entity.ts
+++ b/src/user/models/user.entity.ts
@@ -69,12 +69,13 @@ export class UserEntity {
   @ApiProperty({
     description: 'User avatar id',
     example: 1,
+    nullable: true,
   })
-  @ManyToOne(() => ImageEntity, { eager: true })
+  @ManyToOne(() => ImageEntity, { eager: true, nullable: true })
   @JoinColumn({ name: 'avatar_id' })
   avatar: ImageEntity;
 
-  @Column()
+  @Column({ nullable: true })
   avatar_id: number;
 
   @ApiProperty({

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -123,7 +123,7 @@ export class UserService {
       if (!avatar)
         throw new HttpException(
           `Avatar with id: ${avatar_id} does not exist`,
-          HttpStatus.NOT_FOUND,
+          HttpStatus.BAD_REQUEST,
         );
     }
 

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -114,14 +114,18 @@ export class UserService {
 
   async createUser(dto: CreateUserDto): Promise<UserEntity> {
     const { avatar_id, ...userDetails } = dto;
-    const avatar = await this.imageRepository.findOneBy({
-      id: avatar_id,
-    });
-    if (!avatar)
-      throw new HttpException(
-        `Avatar with id: ${avatar_id} does not exist`,
-        HttpStatus.NOT_FOUND,
-      );
+    let avatar: ImageEntity = null;
+
+    if (avatar_id) {
+      avatar = await this.imageRepository.findOneBy({
+        id: avatar_id,
+      });
+      if (!avatar)
+        throw new HttpException(
+          `Avatar with id: ${avatar_id} does not exist`,
+          HttpStatus.NOT_FOUND,
+        );
+    }
 
     try {
       const defaultSettings = await this.userSettingRepository.create();


### PR DESCRIPTION
* `src/user/dto/create-user.dto.ts` - Allow for the dto.avatar_id to be optional.
* `src/user/models/user.entity.ts` - Set table columns as nullable.
* `src/user/user.service.ts` - Continue checking for proper avatar only if the avatar_id was given.