### PR TITLE
Add auth header support for web scraper endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,6 @@ VERIFICATION_JWT_EXPIRE
 
 # Expects an uri string, eg.: 'https://foo.com/bar'
 VERIFICATION_URI
+
+# Expects a string, eg.: 'secret'
+WEB_SCRAPER_TOKEN

--- a/src/blood-center/blood-center.controller.ts
+++ b/src/blood-center/blood-center.controller.ts
@@ -3,6 +3,7 @@ import {
   ClassSerializerInterceptor,
   Controller,
   Get,
+  Headers,
   HttpStatus,
   Param,
   Post,
@@ -19,6 +20,7 @@ import {
   ApiOkResponse,
   ApiOperation,
   ApiTags,
+  ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { Public } from '../auth/guard/public-route.decorator';
 
@@ -78,9 +80,13 @@ export class BloodCenterController {
     description:
       'Creating new set of Blood Center Details failed. Please check request body',
   })
+  @ApiUnauthorizedResponse({
+    description: 'Requester is not authorized to save Blood Center Details',
+  })
   async createBloodDetailStatus(
     @Body() body: SaveBloodCenterDetailsDto,
+    @Headers('authorization') authHeader: string,
   ): Promise<void> {
-    return this.bloodCenterService.saveBloodCenterDetails(body);
+    return this.bloodCenterService.saveBloodCenterDetails(body, authHeader);
   }
 }

--- a/src/blood-center/blood-center.module.ts
+++ b/src/blood-center/blood-center.module.ts
@@ -5,6 +5,7 @@ import { BloodCenterController } from './blood-center.controller';
 import { BloodCenterEntity } from './models/blood-center.entity';
 import { BloodCenterDetailEntity } from './models/blood-center-detail.entity';
 import { BloodCenterEventEntity } from './models/blood-center-event.entity';
+import { ConfigModule } from '@nestjs/config';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { BloodCenterEventEntity } from './models/blood-center-event.entity';
       BloodCenterDetailEntity,
       BloodCenterEventEntity,
     ]),
+    ConfigModule,
   ],
   providers: [BloodCenterService],
   controllers: [BloodCenterController],

--- a/src/common/utilities/config-validation.schema.ts
+++ b/src/common/utilities/config-validation.schema.ts
@@ -27,4 +27,5 @@ export const configValidationSchema = joi.object({
   VERIFICATION_JWT_SECRET: joi.string().required(),
   VERIFICATION_JWT_EXPIRE: joi.string().default(defaults.JWT_EXPIRE).required(),
   VERIFICATION_URI: joi.string().uri().required(),
+  WEB_SCRAPER_TOKEN: joi.string().required(),
 });


### PR DESCRIPTION
* `.env.example` - new env variable added.
* `src/blood-center/blood-center.controller.ts` - extract authorization header from post request.
* `src/blood-center/blood-center.module.ts` - import config module to access env variables.
* `src/blood-center/blood-center.service.ts` - if auth header is null or its value doesn't match env variable token throw error, else proceed as usual.
* `src/common/utilities/config-validation.schema.ts` - validate new env variable.