### PR TITLE
Dev 116 api modul user testy jednostkowe

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.1.0",
+  "version": "0.9.0",
   "description": "Nest.js Backend for the Blood Donor App",
   "author": "Goodwill Ninjas Team",
   "private": true,

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -2,11 +2,13 @@ import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
 import {
   ApiBearerAuth,
+  ApiExcludeController,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
 } from '@nestjs/swagger';
 
+@ApiExcludeController()
 @ApiTags('Base')
 @Controller('status')
 export class AppController {

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -3,6 +3,8 @@ import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { CreateUserDto } from '../user/dto/create-user.dto';
 import { UserEntity } from '../user/models/user.entity';
+import EmailService from '../email/email.service';
+import { ConfigService } from '@nestjs/config';
 
 describe('AuthController', () => {
   const mockToken = 'mock_token';
@@ -19,6 +21,19 @@ describe('AuthController', () => {
           useValue: {
             register: jest.fn(),
             login: jest.fn(),
+            sendVerificationLink: jest.fn(),
+          },
+        },
+        {
+          provide: EmailService,
+          useValue: {
+            sendMail: jest.fn(),
+          },
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn(),
           },
         },
       ],

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -7,8 +7,10 @@ import { LoginUserDto } from '../user/dto/login-user.dto';
 import { CreateUserDto } from '../user/dto/create-user.dto';
 import { UserEntity } from '../user/models/user.entity';
 import { HttpException, HttpStatus } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import EmailService from '../email/email.service';
 
-describe('AuthController', () => {
+describe('AuthService', () => {
   const mockToken = 'mock_token';
 
   let authService: AuthService;
@@ -18,13 +20,31 @@ describe('AuthController', () => {
     createUser: jest.fn(),
   };
 
+  const mockConfigService = {
+    get: jest.fn(),
+  };
+
+  const mockEmailService = {
+    sendMail: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
-      providers: [AuthService, UserService, JwtService],
+      providers: [
+        AuthService,
+        UserService,
+        JwtService,
+        ConfigService,
+        EmailService,
+      ],
     })
       .overrideProvider(UserService)
       .useValue(mockUserService)
+      .overrideProvider(ConfigService)
+      .useValue(mockConfigService)
+      .overrideProvider(EmailService)
+      .useValue(mockEmailService)
       .compile();
 
     authService = module.get<AuthService>(AuthService);

--- a/src/blood-center/blood-center.controller.spec.ts
+++ b/src/blood-center/blood-center.controller.spec.ts
@@ -5,10 +5,11 @@ import { BloodCenterEntity } from './models/blood-center.entity';
 import { BloodCenterDetailEntity } from './models/blood-center-detail.entity';
 import { SaveBloodCenterDetailsDto } from './dto/save-blood-center-details.dto';
 
-describe('DonationController', () => {
+describe('BloodCenterController', () => {
   const exampleBloodCenter = new BloodCenterEntity();
   const exampleBloodCenterDetails = new BloodCenterDetailEntity();
   const exampleCity = 'Test City';
+  const exampleAuthHeader = 'mock_token';
 
   let controller: BloodCenterController;
 
@@ -51,10 +52,11 @@ describe('DonationController', () => {
   it('Saves Blood Bank capacities', async () => {
     const dto = new SaveBloodCenterDetailsDto();
     await expect(
-      controller.createBloodDetailStatus(dto),
+      controller.createBloodDetailStatus(dto, exampleAuthHeader),
     ).resolves.not.toThrow();
     expect(mockBloodCenterService.saveBloodCenterDetails).toHaveBeenCalledWith(
       dto,
+      exampleAuthHeader,
     );
   });
 

--- a/src/blood-center/blood-center.service.spec.ts
+++ b/src/blood-center/blood-center.service.spec.ts
@@ -5,12 +5,14 @@ import { BloodCenterDetailEntity } from './models/blood-center-detail.entity';
 import { BloodCenterService } from './blood-center.service';
 import { SaveBloodCenterDetailsDto } from './dto/save-blood-center-details.dto';
 import { ParsedBloodCenterDetailRequest } from './interfaces/parsed-blood-center-detail.request';
+import { ConfigService } from '@nestjs/config';
 
-describe('DonationService', () => {
+describe('BloodCenterService', () => {
   const exampleBloodCenter = new BloodCenterEntity();
   const exampleParsedBloodCenterDetailRequest =
     [] as ParsedBloodCenterDetailRequest[];
   const exampleCity = 'Test City';
+  const exampleAuthHeader = 'mock_token';
 
   let service: BloodCenterService;
 
@@ -52,6 +54,12 @@ describe('DonationService', () => {
           provide: getRepositoryToken(BloodCenterDetailEntity),
           useValue: mockBloodCenterDetailRepository,
         },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn().mockReturnValueOnce(exampleAuthHeader),
+          },
+        },
       ],
     }).compile();
 
@@ -90,7 +98,10 @@ describe('DonationService', () => {
       },
     };
     await expect(
-      service.saveBloodCenterDetails(<SaveBloodCenterDetailsDto>(<unknown>dto)),
+      service.saveBloodCenterDetails(
+        <SaveBloodCenterDetailsDto>(<unknown>dto),
+        exampleAuthHeader,
+      ),
     ).resolves.not.toThrow();
     expect(mockBloodCenterDetailRepository.create).toHaveBeenCalledTimes(8);
   });

--- a/src/donation/donation.controller.spec.ts
+++ b/src/donation/donation.controller.spec.ts
@@ -2,16 +2,12 @@ import { DonationController } from './donation.controller';
 import { Test, TestingModule } from '@nestjs/testing';
 import { DonationService } from './donation.service';
 import * as fc from 'fast-check';
+import { CreateDonationDto } from './dto/create-donation.dto';
 
 describe('DonationController', () => {
-  const exampleDonation = {
-    user_id: 720,
-    donated_type: 'whole',
-    amount: 450,
-    blood_pressure: '170/90',
-    donated_at: '2002-02-02T22:22:22.22Z',
-  };
+  const exampleDonation = new CreateDonationDto();
   const exampleId = 1;
+  const exampleAuthHeader = 'mock_token';
 
   let controller: DonationController;
 
@@ -48,21 +44,28 @@ describe('DonationController', () => {
   });
 
   it('Finds a donation', () => {
-    expect(controller.getDonation(exampleId)).toEqual({
+    expect(controller.getDonation(exampleId, exampleAuthHeader)).toEqual({
       id: exampleId,
       ...exampleDonation,
     });
   });
 
   it('Creates a donation', () => {
-    expect(controller.addDonation(exampleDonation)).resolves.toEqual({
+    expect(
+      controller.addDonation(exampleDonation, exampleAuthHeader),
+    ).resolves.toEqual({
       id: fc.integer(),
       ...exampleDonation,
     });
   });
 
   it('Should delete a donation', async () => {
-    await expect(controller.deleteDonation(exampleId)).resolves.not.toThrow();
-    expect(mockDonationService.removeDonation).toHaveBeenCalledWith(exampleId);
+    await expect(
+      controller.deleteDonation(exampleId, exampleAuthHeader),
+    ).resolves.not.toThrow();
+    expect(mockDonationService.removeDonation).toHaveBeenCalledWith(
+      exampleId,
+      exampleAuthHeader,
+    );
   });
 });

--- a/src/donation/donation.service.spec.ts
+++ b/src/donation/donation.service.spec.ts
@@ -7,13 +7,15 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 
 describe('DonationService', () => {
   const exampleDonation = {
-    user_id: 720,
+    user_id: 1,
     donated_type: 'whole',
     amount: 450,
     blood_pressure: '170/90',
     donated_at: '2002-02-02T22:22:22.22Z',
+    disqualified: false,
   };
   const exampleId = 1;
+  const exampleAuthHeader = 'mock_token';
 
   let service: DonationService;
 
@@ -70,18 +72,23 @@ describe('DonationService', () => {
   });
 
   it('Should create donation', () => {
-    expect(service.createDonation(exampleDonation)).resolves.toEqual({
+    expect(
+      service.createDonation(exampleDonation, exampleAuthHeader),
+    ).resolves.toEqual({
       id: exampleId,
-      user: 720,
+      user: 1,
       donated_type: 'whole',
       amount: 450,
       blood_pressure: '170/90',
       donated_at: '2002-02-02T22:22:22.22Z',
+      disqualified: false,
     });
   });
 
   it('Should remove donation', async () => {
-    await expect(service.removeDonation(exampleId)).resolves.not.toThrow();
+    await expect(
+      service.removeDonation(exampleId, exampleAuthHeader),
+    ).resolves.not.toThrow();
     expect(mockDonationRepository.softDelete).toHaveBeenCalledWith(exampleId);
   });
 });

--- a/src/donation/dto/create-donation.dto.ts
+++ b/src/donation/dto/create-donation.dto.ts
@@ -92,7 +92,7 @@ export class CreateDonationDto {
   })
   @IsOptional()
   @IsEnum(ArmType)
-  arm: string;
+  arm?: string;
 
   @ApiProperty({
     description: 'Time of the donation',

--- a/src/donation/dto/create-donation.dto.ts
+++ b/src/donation/dto/create-donation.dto.ts
@@ -72,7 +72,7 @@ export class CreateDonationDto {
     example: 140,
     nullable: true,
   })
-  @IsString()
+  @IsNumber()
   @IsOptional()
   hemoglobin?: number;
 
@@ -87,7 +87,7 @@ export class CreateDonationDto {
 
   @ApiProperty({
     description: 'Which arm was used during donation',
-    example: 'Left',
+    example: 'left',
     nullable: true,
   })
   @IsOptional()

--- a/src/donation/models/donation.entity.ts
+++ b/src/donation/models/donation.entity.ts
@@ -11,6 +11,7 @@ import {
 import { UserEntity } from '../../user/models/user.entity';
 import { ApiProperty } from '@nestjs/swagger';
 import { Exclude } from 'class-transformer';
+import { IsOptional } from 'class-validator';
 
 @Entity('donation')
 export class DonationEntity {
@@ -44,9 +45,9 @@ export class DonationEntity {
 
   @ApiProperty({
     description: 'ID of user accompanying the requester',
-    example: 2,
     nullable: true,
   })
+  @IsOptional()
   @Column({ nullable: true })
   companion_user_id: number;
 
@@ -54,6 +55,7 @@ export class DonationEntity {
     nullable: true,
     onDelete: 'SET NULL',
   })
+  @IsOptional()
   @JoinColumn({ name: 'companion_user_id' })
   companion_user: UserEntity;
 
@@ -83,9 +85,9 @@ export class DonationEntity {
 
   @ApiProperty({
     description: 'Hemoglobin levels in g/l',
-    example: 140,
     nullable: true,
   })
+  @IsOptional()
   @Column({ nullable: true })
   hemoglobin: number;
 
@@ -100,7 +102,7 @@ export class DonationEntity {
 
   @ApiProperty({
     description: 'Which arm was used during donation',
-    example: 'Left',
+    example: 'left',
     nullable: true,
   })
   @Column({ nullable: true })

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -9,11 +9,13 @@ import {
 } from '@nestjs/terminus';
 import {
   ApiBearerAuth,
+  ApiExcludeController,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
 } from '@nestjs/swagger';
 
+@ApiExcludeController()
 @ApiTags('Base')
 @Controller('health')
 export class HealthController {

--- a/src/user/dto/create-user.dto.ts
+++ b/src/user/dto/create-user.dto.ts
@@ -37,7 +37,7 @@ export class CreateUserDto {
 
   @ApiProperty({
     description: 'User blood type',
-    example: 'AB-',
+    example: 'AB Rh-',
   })
   @IsNotEmpty()
   @IsEnum(BloodType)
@@ -53,7 +53,6 @@ export class CreateUserDto {
 
   @ApiProperty({
     description: 'User avatar id',
-    example: 1,
     nullable: true,
   })
   @IsOptional()

--- a/src/user/dto/create-user.dto.ts
+++ b/src/user/dto/create-user.dto.ts
@@ -57,5 +57,5 @@ export class CreateUserDto {
   })
   @IsOptional()
   @IsNumber()
-  avatar_id: number;
+  avatar_id?: number;
 }

--- a/src/user/dto/user-with-experience-details.dto.ts
+++ b/src/user/dto/user-with-experience-details.dto.ts
@@ -7,7 +7,6 @@ import { IsEmail, IsEnum, IsString } from 'class-validator';
 import { BloodType } from '../../common/enum/blood-type.enum';
 import { GenderIdentity } from '../../common/enum/gender-identity.enum';
 import { ExperienceDetails } from '../interfaces/experience-details';
-import { Exclude } from 'class-transformer';
 
 export class UserWithExperienceDetails
   implements

--- a/src/user/dto/user-with-experience-details.dto.ts
+++ b/src/user/dto/user-with-experience-details.dto.ts
@@ -7,6 +7,7 @@ import { IsEmail, IsEnum, IsString } from 'class-validator';
 import { BloodType } from '../../common/enum/blood-type.enum';
 import { GenderIdentity } from '../../common/enum/gender-identity.enum';
 import { ExperienceDetails } from '../interfaces/experience-details';
+import { Exclude } from 'class-transformer';
 
 export class UserWithExperienceDetails
   implements

--- a/src/user/user.controller.spec.ts
+++ b/src/user/user.controller.spec.ts
@@ -1,0 +1,101 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserController } from './user.controller';
+import { UserService } from './user.service';
+import { UserWithExperienceDetails } from './dto/user-with-experience-details.dto';
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { DonationEntity } from '../donation/models/donation.entity';
+import { UserCompletedFeat } from './dto/user-completed-feat.dto';
+import { UserEntity } from './models/user.entity';
+
+describe('UserController', () => {
+  const mockToken = 'mock_token';
+  const mockDonation = new DonationEntity();
+  const mockUserFeat = new UserCompletedFeat();
+  const mockUser = new UserEntity();
+  const mockUserWithExp = new UserWithExperienceDetails();
+  const mockId = 1;
+  mockUserWithExp.id = mockId;
+
+  let controller: UserController;
+  const mockUserService = {
+    findUsers: jest.fn(() => [mockUser]),
+    findUserById: jest.fn((id: number) => {
+      if (id === mockUserWithExp.id) return mockUserWithExp;
+      throw new HttpException('User not found', HttpStatus.NOT_FOUND);
+    }),
+    findUserDonations: jest.fn(() => [mockDonation]),
+    findUserCompletedFeats: jest.fn(() => [mockUserFeat]),
+    removeUser: jest.fn(),
+    updateUser: jest.fn(
+      (_id: number, _mockToken: string, body: { username: string }) => {
+        mockUserWithExp.username = body.username;
+        return mockUserWithExp;
+      },
+    ),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UserController],
+      providers: [
+        {
+          provide: UserService,
+          useValue: mockUserService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<UserController>(UserController);
+  });
+
+  it('Should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('Returns a list of all users', () => {
+    expect(controller.getAllUsers()).resolves.toEqual([mockUser]);
+  });
+
+  it('If exists, returns an user with corresponding id', () => {
+    expect(controller.getUser(mockId, mockToken)).resolves.toEqual(
+      mockUserWithExp,
+    );
+  });
+
+  it('Throws error if user with given id does not exist', () => {
+    const throwableId = 9;
+    expect(controller.getUser(throwableId, mockToken)).rejects.toThrow(
+      'User not found',
+    );
+  });
+
+  it('Returns user donations', () => {
+    expect(controller.getUserDonations(mockId, mockToken)).resolves.toEqual([
+      mockDonation,
+    ]);
+  });
+
+  it('Returns user feats', () => {
+    expect(controller.getUserFeats(mockId, mockToken)).resolves.toEqual([
+      mockUserFeat,
+    ]);
+  });
+
+  it('Removes user', async () => {
+    await expect(
+      controller.deleteUser(mockId, mockToken),
+    ).resolves.not.toThrow();
+
+    expect(mockUserService.removeUser).toHaveBeenCalledWith(mockId, mockToken);
+  });
+
+  it('Updates user details', () => {
+    const username = 'foo';
+    expect(
+      controller.patchUser(mockId, mockToken, { username }),
+    ).resolves.toEqual({
+      ...mockUserWithExp,
+      username,
+    });
+  });
+});

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -15,6 +15,7 @@ import { UserService } from './user.service';
 import {
   ApiBearerAuth,
   ApiConflictResponse,
+  ApiExcludeEndpoint,
   ApiForbiddenResponse,
   ApiNoContentResponse,
   ApiNotFoundResponse,
@@ -35,6 +36,7 @@ export class UserController {
   constructor(private readonly userService: UserService) {}
 
   @Get()
+  @ApiExcludeEndpoint()
   @ApiBearerAuth()
   @ApiOperation({
     summary: 'Get Users',

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -1,0 +1,188 @@
+import { UserService } from './user.service';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { UserEntity } from './models/user.entity';
+import { AuthService } from '../auth/auth.service';
+import { UserSettingEntity } from './models/user-setting.entity';
+import { DonationEntity } from '../donation/models/donation.entity';
+import { ImageEntity } from '../image/models/image.entity';
+import { FeatEntity } from '../feat/models/feat.entity';
+import { FeatCompletionEntity } from '../feat/models/feat-completion.entity';
+import { UserWithExperienceDetails } from './dto/user-with-experience-details.dto';
+import { CreateUserDto } from './dto/create-user.dto';
+
+describe('UserService', () => {
+  const mockToken = 'mock_token';
+  const mockDonation = new DonationEntity();
+  const mockUser = new UserEntity();
+  const mockUserSetting = new UserSettingEntity();
+  const mockUserWithExp = new UserWithExperienceDetails();
+  const mockId = 1;
+  const mockEmail = 'foo@bar.com';
+
+  let service: UserService;
+
+  const mockAuthService = {
+    isUserAuthorizedToAccessData: jest.fn((token: string) => !!token),
+  };
+  const mockUserRepository = {
+    find: jest.fn(() => [mockUser]),
+    createQueryBuilder: jest.fn(() => ({
+      innerJoinAndSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      getOne: jest.fn(() => {
+        mockUserWithExp.expDetails = {
+          currentExperience: undefined,
+          level: 10,
+          maxExperience: 0,
+          minExperience: 7770,
+        };
+        return mockUserWithExp;
+      }),
+    })),
+    calculateLevel: jest.fn().mockReturnThis(),
+    create: jest.fn(() => mockUser),
+    save: jest.fn().mockReturnThis(),
+    delete: jest.fn(async () => ({ affected: 1 })),
+    update: jest.fn((id: number, body: { username: string }) => {
+      mockUserWithExp.username = body.username;
+      return mockUserWithExp;
+    }),
+  };
+  const mockUserSettingRepository = {
+    create: jest.fn().mockReturnThis(),
+    save: jest.fn().mockReturnThis(),
+    createQueryBuilder: jest.fn(() => ({
+      where: jest.fn().mockReturnThis(),
+      getOne: jest.fn(() => mockUserSetting),
+    })),
+    update: jest.fn().mockReturnThis(),
+  };
+  const mockDonationRepository = {
+    find: jest.fn().mockReturnValueOnce([mockDonation]),
+    createQueryBuilder: jest.fn(() => ({
+      softDelete: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      execute: jest.fn().mockReturnThis(),
+    })),
+  };
+  const mockImageRepository = {};
+  const mockFeatRepository = {
+    find: jest
+      .fn()
+      .mockResolvedValue([
+        { id: 1, name: 'Feat 1', description: 'Description 1', ranks: [] },
+      ]),
+  };
+  const mockFeatCompletionRepository = {
+    query: jest.fn().mockResolvedValue([{ feat_id: 1, achieved_feat_rank: 3 }]),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserService,
+        {
+          provide: AuthService,
+          useValue: mockAuthService,
+        },
+        {
+          provide: getRepositoryToken(UserEntity),
+          useValue: mockUserRepository,
+        },
+        {
+          provide: getRepositoryToken(UserSettingEntity),
+          useValue: mockUserSettingRepository,
+        },
+        {
+          provide: getRepositoryToken(DonationEntity),
+          useValue: mockDonationRepository,
+        },
+        {
+          provide: getRepositoryToken(ImageEntity),
+          useValue: mockImageRepository,
+        },
+        {
+          provide: getRepositoryToken(FeatEntity),
+          useValue: mockFeatRepository,
+        },
+        {
+          provide: getRepositoryToken(FeatCompletionEntity),
+          useValue: mockFeatCompletionRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<UserService>(UserService);
+  });
+
+  it('Should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('Finds all users', () => {
+    expect(service.findUsers()).resolves.toEqual([mockUser]);
+  });
+
+  it('Returns user with corresponding id', () => {
+    expect(service.findUserById(mockId, mockToken)).resolves.toEqual(
+      mockUserWithExp,
+    );
+  });
+
+  it('Returns user with corresponding email', () => {
+    expect(service.findUserByEmail(mockEmail)).resolves.toEqual(
+      mockUserWithExp,
+    );
+  });
+
+  it('Return user donations', () => {
+    expect(service.findUserDonations(mockId, mockToken)).resolves.toEqual([
+      mockDonation,
+    ]);
+  });
+
+  it('Return user completed feats', () => {
+    expect(service.findUserCompletedFeats(mockId, mockToken)).resolves.toEqual([
+      {
+        userId: 1,
+        featId: 1,
+        featName: 'Feat 1',
+        featDescription: 'Description 1',
+        achievedRanks: [],
+        nextRanks: [],
+      },
+    ]);
+  });
+
+  it('Creates a new user', () => {
+    expect(service.createUser(new CreateUserDto())).resolves.toEqual(mockUser);
+  });
+
+  it('Removes an user', async () => {
+    await expect(service.removeUser(mockId, mockToken)).resolves.not.toThrow();
+
+    expect(mockAuthService.isUserAuthorizedToAccessData).toHaveBeenCalledWith(
+      mockId,
+      mockToken,
+    );
+  });
+
+  it('Updates user', () => {
+    const username = 'foo';
+    expect(
+      service.updateUser(mockId, mockToken, { username }),
+    ).resolves.toEqual({
+      ...mockUserWithExp,
+      username,
+    });
+  });
+
+  it('Updates user email verification field', async () => {
+    await expect(service.updateUserEmailVerification(mockId));
+    expect(mockUserRepository.update).toHaveBeenCalledWith(
+      { id: mockId },
+      { has_verified_email: true },
+    );
+  });
+});

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -71,6 +71,7 @@ export class UserService {
 
     const expDetails = this.calculateLevel(user.experience);
     delete user['experience'];
+    delete user['password'];
     return {
       ...user,
       expDetails,


### PR DESCRIPTION
Mostly minor things + tests.
Proof of tests executing:
![image](https://github.com/goodwill-ninjas/backend/assets/39565249/f1974d9e-ee98-4585-b640-a0a5328735de)



Fixes & minor stuff:
* `package.json` - Version bump :)
* `src/app.controller.ts` - Excluding "Base" (health checks) from swagger docs as these are not public endpoints.
* `src/auth/auth.controller.spec.ts`,  `src/auth/auth.service.spec.ts` - Fixing AuthController by injecting mock Email/Config services.
* `src/blood-center/blood-center.controller.spec.ts` - Fixing `describe()` typo + fixing test by adding mock auth header.
* `src/blood-center/blood-center.service.spec.ts` - Same as above but also implementing handling for the auth header.
* `src/donation/donation.controller.spec.ts`, `src/donation/donation.service.spec.ts` - Same as the blood-center pair above.
* `src/donation/dto/create-donation.dto.ts`, `src/donation/models/donation.entity.ts` - Fixing DonationDto docs + Hemoglobin property should be a number, not a string. Also, arm is optional property.
* `src/health/health.controller.ts` - Excluding health check endpoints from public endpoints.
* `src/user/dto/create-user.dto.ts` - Fixing docs; proper blood type & avatar_id is optional.
-- These two files are a bit later in the file list but are minor things:
* `src/user/user.controller.ts` - Excluding GetAllUsers() from public docs.
* `src/user/user.service.ts` - Bug fix, removing password from the user response.

User Tests, kinda messy, a lot of mocking because user module has the most dependencies out of all modules and is the heart of the api.
* `src/user/user.controller.spec.ts` - user controller unit tests
* `src/user/user.service.spec.ts` - user service unit tests